### PR TITLE
Add DialogFlow version code on GET requests

### DIFF
--- a/php/digitalhigh/dialogFlow/DialogFlow.php
+++ b/php/digitalhigh/dialogFlow/DialogFlow.php
@@ -94,7 +94,7 @@ class DialogFlow {
 		$params = array_merge(['v'=>$this->version],$params);
 
 		if ( $params['type'] == 'get' ) {
-			$url = $this->url . $params['uri'] . '?' . http_build_query($params['data']);
+			$url = $this->url . $params['uri'] . '?v=20150910&' . http_build_query($params['data']);
 			$this->lastUrl=$url;
 			return $client->get($url, $options);
 		}


### PR DESCRIPTION
Based on information from https://forums.plex.tv/u/rpw128 & https://dialogflow.com/docs/reference/agent#protocol_version

Adds the correct version code required by DialogFlow onto every GET request, fixing many exception throwing issues.